### PR TITLE
fix: File PR#16 comment 수정

### DIFF
--- a/src/main/java/com/sprint/project/hrbank/controller/FileController.java
+++ b/src/main/java/com/sprint/project/hrbank/controller/FileController.java
@@ -1,22 +1,19 @@
 package com.sprint.project.hrbank.controller;
 
-import com.sprint.project.hrbank.dto.common.FileResponse;
+import com.sprint.project.hrbank.dto.file.FileResponse;
 import com.sprint.project.hrbank.service.FileService;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import lombok.RequiredArgsConstructor;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/files")
@@ -25,35 +22,66 @@ public class FileController {
 
   private final FileService fileService;
 
-  // 파일 다운로드 API 공개 엔드 포인트
-  // GET /api/files/{id}/download
-
-  // meta(id, fileName, contentType, size)를 조회해 응답 헤더에 반영한다.
-  // 실제 파일은 storage/{id}에서 읽어 반환한다.
-  // 예외는 exception.GlobalExceptionHandler에서 처리한다.
-
-  @GetMapping("/{id}/download")
-  public ResponseEntity<FileSystemResource> download(@PathVariable Long id) {
-
-    // meta 조회: fileName/contentType 헤더에 사용한다.
-    FileResponse meta = fileService.getMeta(id);
-
-    //실제 파일 리소스
-    FileSystemResource resource = fileService.download(id);
-
-    //fileName 한글 and 특수문자 안전 처리
-    String fileName = StringUtils.hasText(meta.fileName()) ? meta.fileName() : String.valueOf(id);
-    String encoded = URLEncoder.encode(fileName, StandardCharsets.UTF_8).replace("+", "%20");
-    String contentDisposition =
-        "attachment; filename=\"" + fileName.replace("\"", "") + "\"; filename*=UTF-8''" + encoded;
-
-    //Content Type meta에 없거나 빈칸이면 octet-stream
-    String contentType = StringUtils.hasText(meta.contentType()) ? meta.contentType()
-        : MediaType.APPLICATION_OCTET_STREAM_VALUE;
-
-    return ResponseEntity.ok().header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
-        .contentType(MediaType.parseMediaType(contentType)).body(resource);
+  // 파일명 정규화(+ null/blank 방어)
+  private String normalizeFileName(String fileName) {
+    String normalName = (fileName == null || fileName.isBlank()) ? "이름없음" : fileName.trim();
+    normalName = normalName.chars()
+        .filter(c -> c >= 32 && c != 127)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
+    normalName = normalName.replaceAll("[\\\\/:*?\"<>|]", "_");
+    normalName = normalName.replaceAll("\\s+", " ");
+    if (normalName.equals(".") || normalName.equals("..")) {
+      normalName = "file";
+    }
+    if (normalName.length() > 255) {
+      normalName = normalName.substring(0, 255);
+    }
+    return normalName;
   }
 
-}
+  // Content-Type 정규화(+ null/blank 방어)
+  private String normalizeContentType(String contentType) {
+    if (contentType == null || contentType.isBlank()) {
+      return MediaType.APPLICATION_OCTET_STREAM_VALUE;
+    }
+    String t = contentType.trim().toLowerCase();
+    return t.matches("^[\\w!#$&^_.+-]+/[\\w!#$&^_.+-]+$") ? t
+        : MediaType.APPLICATION_OCTET_STREAM_VALUE;
+  }
 
+  // (팀내 사용) 업로드 – 스펙 공개 엔드포인트가 필요 없으면 이 메서드는 삭제해도 됨
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<FileResponse> upload(@RequestPart("file") MultipartFile file) {
+    if (file == null || file.isEmpty()) {
+      return ResponseEntity.badRequest().build();
+    }
+    final String safeFileName = normalizeFileName(file.getOriginalFilename());
+    final String safeContentType = normalizeContentType(file.getContentType());
+
+    FileResponse saved = fileService.upload(file, safeFileName, safeContentType);
+    return ResponseEntity.ok(saved);
+  }
+
+  // 다운로드 (공개 스펙)
+  @GetMapping("/{id}/download")
+  public ResponseEntity<FileSystemResource> download(@PathVariable Long id) {
+    FileResponse meta = fileService.getMeta(id);
+    FileSystemResource resource = fileService.download(id);
+
+    String fileName = StringUtils.hasText(meta.fileName()) ? meta.fileName() : String.valueOf(id);
+    String asciiFileName = fileName.replace("\"", "");
+    String encoded = URLEncoder.encode(fileName, StandardCharsets.UTF_8).replace("+", "%20");
+    String contentDisposition =
+        "attachment; filename=\"" + asciiFileName + "\"; filename*=UTF-8''" + encoded;
+
+    String contentType = StringUtils.hasText(meta.contentType())
+        ? meta.contentType()
+        : MediaType.APPLICATION_OCTET_STREAM_VALUE;
+
+    return ResponseEntity.ok()
+        .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
+        .contentType(MediaType.parseMediaType(contentType))
+        .body(resource);
+  }
+}

--- a/src/main/java/com/sprint/project/hrbank/dto/common/FileResponse.java
+++ b/src/main/java/com/sprint/project/hrbank/dto/common/FileResponse.java
@@ -1,5 +1,0 @@
-package com.sprint.project.hrbank.dto.common;
-
-public record FileResponse(Long id, String fileName, String contentType, Long size) {
-
-}

--- a/src/main/java/com/sprint/project/hrbank/dto/file/FileResponse.java
+++ b/src/main/java/com/sprint/project/hrbank/dto/file/FileResponse.java
@@ -1,0 +1,10 @@
+package com.sprint.project.hrbank.dto.file;
+
+public record FileResponse(
+    Long id,
+    String fileName,
+    String contentType,
+    Long size
+) {
+
+}

--- a/src/main/java/com/sprint/project/hrbank/entity/File.java
+++ b/src/main/java/com/sprint/project/hrbank/entity/File.java
@@ -2,27 +2,19 @@ package com.sprint.project.hrbank.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
-import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
 @Entity
 @Table(name = "files")
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
 public class File {
 
   @Id
@@ -30,12 +22,17 @@ public class File {
   private Long id;
 
   //@Column의 length = 255이 기본값
-  @Column(name = "file_name")
   private String fileName;
 
-  @Column(name = "content_type", length = 100)
+  @Column(length = 100)
   private String contentType;
 
-  @Column()
   private long size;
+
+  // PK(id)는 제외하고 필요한 필드만 받는 생성자
+  public File(String fileName, String contentType, long size) {
+    this.fileName = fileName;
+    this.contentType = contentType;
+    this.size = size;
+  }
 }

--- a/src/main/java/com/sprint/project/hrbank/exception/FileStorageException.java
+++ b/src/main/java/com/sprint/project/hrbank/exception/FileStorageException.java
@@ -1,0 +1,12 @@
+package com.sprint.project.hrbank.exception;
+
+public class FileStorageException extends RuntimeException {
+
+  public FileStorageException(String message) {
+    super(message);
+  }
+
+  public FileStorageException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/sprint/project/hrbank/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprint/project/hrbank/exception/GlobalExceptionHandler.java
@@ -23,36 +23,41 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ErrorResponse> handleBadRequest(Exception e) {
     log.warn("Bad Request: {}", e.getMessage(), e);
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.builder()
-        .timestamp(Instant.now())
-        .message("Bad Request")
-        .status(HttpStatus.BAD_REQUEST.value())
-        .details(safeDetail(e))
-        .build());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+        ErrorResponse.builder().timestamp(Instant.now()).message("Bad Request")
+            .status(HttpStatus.BAD_REQUEST.value()).details(safeDetail(e)).build());
   }
 
   @ExceptionHandler(NoSuchElementException.class)
   public ResponseEntity<ErrorResponse> handleNotFound(Exception e) {
     log.warn("Not Found: {}", e.getMessage(), e);
 
-    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.builder()
-        .timestamp(Instant.now())
-        .message("Not Found")
-        .status(HttpStatus.NOT_FOUND.value())
-        .details(safeDetail(e))
-        .build());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+        ErrorResponse.builder().timestamp(Instant.now()).message("Not Found")
+            .status(HttpStatus.NOT_FOUND.value()).details(safeDetail(e)).build());
   }
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleServerError(Exception e) {
     log.error("Internal Server Error: {}", e.getMessage(), e);
 
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.builder()
-        .timestamp(Instant.now())
-        .message("Internal Server Error")
-        .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
-        .details(safeDetail(e))
-        .build());
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+        ErrorResponse.builder().timestamp(Instant.now()).message("Internal Server Error")
+            .status(HttpStatus.INTERNAL_SERVER_ERROR.value()).details(safeDetail(e)).build());
   }
 
+  //FileStorageException 처리 추가
+  @ExceptionHandler(FileStorageException.class)
+  public ResponseEntity<ErrorResponse> handleFileStorageException(Exception e) {
+    log.error("File Storage Error: {}", e.getMessage(), e);
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+        ErrorResponse.builder()
+            .timestamp(Instant.now())
+            .message("File Storage Error")
+            .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+            .details(safeDetail(e))
+            .build()
+    );
+  }
 }

--- a/src/main/java/com/sprint/project/hrbank/service/FileService.java
+++ b/src/main/java/com/sprint/project/hrbank/service/FileService.java
@@ -1,7 +1,8 @@
 package com.sprint.project.hrbank.service;
 
+import com.sprint.project.hrbank.dto.file.FileResponse;
 import com.sprint.project.hrbank.entity.File;
-import com.sprint.project.hrbank.dto.common.FileResponse;
+import com.sprint.project.hrbank.exception.FileStorageException;
 import com.sprint.project.hrbank.repository.FileRepository;
 
 import java.io.IOException;
@@ -10,13 +11,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import lombok.RequiredArgsConstructor;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -24,76 +26,47 @@ public class FileService {
 
   private final FileRepository fileRepository;
 
-  // application.yml 에서 hrbank.storage.root 값을 읽어옴
-  // 설정이 없으면 기본값 "./storage" 사용
   @Value("${hrbank.storage.root:./storage}")
   private String storageRoot;
 
-  //파일 업로드 서비스
   @Transactional
-  public FileResponse upload(MultipartFile multifile) throws IOException {
-    // 원본 이름, 타입, 크기 추출
-    final String rawName = multifile.getOriginalFilename();
-    final String rawType = multifile.getContentType();
-    final long size = multifile.getSize(); // size는 primitive long → null 불가
+  public FileResponse upload(MultipartFile multifile, String fileName, String contentType) {
+    final long size = multifile.getSize();
 
-    // Null/빈값 방어
-    // isBlank()는 빈 문자열("") + 공백("   ") 모두 true → fileName이 공백만 있어도 "이름없음"으로 대체됨 isEmpty()보다 더 안전
-    final String fileName =
-        (rawName == null || rawName.isBlank()) ? "이름없음" : rawName;
-
-    // MIME 타입이 null/빈값이면 "application/octet-stream" (일반적인 바이너리 타입)으로 대체
-    final String contentType =
-        (rawType == null || rawType.isBlank()) ? "application/octet-stream" : rawType;
-
-    // 1. 메타데이터 DB 저장 (id 자동 생성)
-    File meta = new File(null, fileName, contentType, size);
+    File meta = new File(fileName, contentType, size);
     meta = fileRepository.save(meta);
 
-    // 2. 실제 파일 저장 경로: storage/{id}
     final Path root = Path.of(storageRoot);
-    Files.createDirectories(root); // 디렉토리 없으면 생성
-
-    final Path dest = root.resolve(String.valueOf(meta.getId()));
-
-    try (InputStream inputStream = multifile.getInputStream()) {
-      // 파일 저장 (기존 파일 있으면 덮어쓰기)
-      Files.copy(inputStream, dest, StandardCopyOption.REPLACE_EXISTING);
+    try {
+      Files.createDirectories(root);
+      final Path dest = root.resolve(String.valueOf(meta.getId()));
+      try (InputStream inputStream = multifile.getInputStream()) {
+        Files.copy(inputStream, dest, StandardCopyOption.REPLACE_EXISTING);
+      }
+      return new FileResponse(meta.getId(), fileName, contentType, size);
     } catch (IOException e) {
-      // 디스크 저장 실패 → 메타데이터 롤백 (DB/디스크 불일치 방지)
       fileRepository.deleteById(meta.getId());
-      throw e; // 예외 다시 던져서 호출자에게 알림
+      throw new FileStorageException("디스크 저장에 실패했습니다. id: " + meta.getId(), e);
     }
-
-    // 업로드 결과 반환 DTO
-    return new FileResponse(meta.getId(), fileName, contentType, size);
   }
 
-  //파일 메타 정보 조회
-  //DB에서만 확인 → 실제 파일은 확인하지 않음
   @Transactional(readOnly = true)
   public FileResponse getMeta(Long id) {
     File meta = fileRepository.findById(id)
-        .orElseThrow(() -> new IllegalArgumentException("파일을 찾을 수 없습니다. id=" + id));
-
+        .orElseThrow(() -> new NoSuchElementException("파일 메타 정보를 찾을 수 없습니다. id: " + id));
     return new FileResponse(meta.getId(), meta.getFileName(), meta.getContentType(),
         meta.getSize());
   }
 
-  //파일 다운로드
   @Transactional(readOnly = true)
   public FileSystemResource download(Long id) {
-    // 1. DB 메타 존재 확인
     fileRepository.findById(id)
-        .orElseThrow(() -> new IllegalArgumentException("파일을 찾을 수 없습니다. id=" + id));
+        .orElseThrow(() -> new NoSuchElementException("파일 메타 정보를 찾을 수 없습니다. id: " + id));
 
-    // 2. 디스크에 실제 파일 존재 확인
     Path filePath = Path.of(storageRoot, String.valueOf(id));
     if (!Files.exists(filePath)) {
-      throw new IllegalArgumentException("디스크에서 파일을 찾을 수 없습니다. path=" + filePath);
+      throw new FileStorageException("디스크에서 파일을 찾을 수 없습니다. path: " + filePath);
     }
-    // 두 레이어(DB/디스크)를 각각 확인하여 안정성 확보
-    // 파일 리소스를 Spring MVC에서 바로 ResponseEntity로 반환 가능
     return new FileSystemResource(filePath);
   }
 }


### PR DESCRIPTION
## 📌 제목

\[feat] 파일 업로드/다운로드 기능 및 예외 처리 개선

---

## 📖 작업 개요

파일 관리 기능을 구현하고 안정성을 강화했습니다.
업로드/다운로드 시 파일명과 Content-Type 방어 로직을 컨트롤러에서 수행하고,
서비스 레이어에서는 저장 실패 시 메타데이터 롤백 및 커스텀 예외를 던지도록 개선했습니다.

---

## ✨ 주요 변경 사항

* FileController

  * 업로드 시 파일명/Content-Type 정규화 및 방어 로직 추가
  * 다운로드 시 filename, filename\* (RFC 5987) 동시 세팅
  * Content-Type 없거나 빈 값일 경우 `application/octet-stream` 기본값 적용
* FileService

  * 업로드 실패 시 DB 메타데이터 롤백 처리
  * `FileStorageException` 커스텀 예외 도입
  * `NoSuchElementException`을 사용하여 404 응답과 일관되게 처리
* File 엔티티

  * PK(id) 제외한 커스텀 생성자 추가, `@AllArgsConstructor` 제거로 안전성 확보
* GlobalExceptionHandler

  * FileStorageException 핸들러 추가
  * 모든 예외 응답에 `details` 포함되도록 수정

---

## 🔍 관련 이슈

#3 머지되면 관련이슈 종료 하겠습니다.
---

## 📝 체크리스트

* [x] 브랜치명은 규칙(`feature/*`, `fix/*`)에 맞게 생성되었나요?
* [x] Commit 메시지가 컨벤션에 맞나요?
* [x] PR 설명에 충분한 맥락이 담겨 있나요?
* [x] Swagger / API 명세 업데이트가 반영되었나요?
* [] 단위/통합 테스트가 추가되었거나 통과했나요?
* [] README / 팀 문서 (Notion 등)에 필요한 업데이트를 반영했나요?

---

## 🧪 테스트 방법

---

## 💬 기타 공유 사항

* 업로드 API는 내부 관리용이며, 외부 공개 스펙에는 다운로드 API만 반영됨

---

## ✅ 리뷰 가이드

* 최소 1명 이상의 Approve 필요
* Conflict 발생 시 팀 채널에 공유 후 해결
* Draft 상태에서는 Merge 불가

---
